### PR TITLE
fix issues with compiling of the pom, remove some unnecessary content

### DIFF
--- a/.strata.yml
+++ b/.strata.yml
@@ -1,0 +1,11 @@
+pipeline_template: jar/Jenkinsfile-1
+email_reply_to: mc-hypergage@salesforce.com
+time_out_mins: 15
+number_of_artifacts_to_keep: 3                        # (Optional) default shown
+compliance_required: false                            # (Optional) default shown
+docker_test_images:
+  - dva/sfdc_centos7_java8_build
+unit_tests_command: echo "no tests included"
+publish_jar_image: dva/sfdc_centos7_java8_build_hypergage
+production_branch:
+  - master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+#GUSINFO:MCIS - Operations Team,MCIS Operations
+*

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.evergage.thirdparty</groupId>
+    <groupId>com.evergage.thirdparty.sourcemap</groupId>
     <artifactId>sourcemap</artifactId>
     <version>1.2.1-evg1</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.atlassian.sourcemap</groupId>
+    <groupId>com.evergage.thirdparty</groupId>
     <artifactId>sourcemap</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1-evg1</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
This commit prepares the repository for salesforce, which requires that the
evergage-product dependencies be within the com.evergage namespace.

It might be worth noting that [this commit](https://github.com/evergage/sourcemap/commit/79a7dfbd931d76ba145f36f437e60f107adab8b2) specifically switched to the `SNAPSHOT` version, but I think we have to switch back to `evg1` for salesforce, as described in the "Evergage Build Audit" spreadsheet